### PR TITLE
27 apikey model initial setting

### DIFF
--- a/src/craConfigManager.ts
+++ b/src/craConfigManager.ts
@@ -42,3 +42,14 @@ export async function checkApiKeyValidation(context: vscode.ExtensionContext) {
     showApiKeyError(context);
   }
 }
+
+export async function showApiKeyError(context: vscode.ExtensionContext) {
+  const result = await vscode.window.showErrorMessage(
+    "OpenAI API key is not configured.\nWant to configure?",
+    "YES",
+    "NO"
+  );
+  if (result === "YES") {
+    setAPIKey(context);
+  }
+}

--- a/src/craConfigManager.ts
+++ b/src/craConfigManager.ts
@@ -37,3 +37,8 @@ export async function onFirstActivation(context: vscode.ExtensionContext) {
   await showModelSelectionQuickPick();
 }
 
+export async function checkApiKeyValidation(context: vscode.ExtensionContext) {
+  if (!(await context.secrets.get("OPENAI_API_KEY"))) {
+    showApiKeyError(context);
+  }
+}

--- a/src/craConfigManager.ts
+++ b/src/craConfigManager.ts
@@ -31,3 +31,9 @@ export async function showModelSelectionQuickPick() {
     },
   });
 }
+
+export async function onFirstActivation(context: vscode.ExtensionContext) {
+  await setAPIKey(context);
+  await showModelSelectionQuickPick();
+}
+

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -13,7 +13,9 @@ export async function activate(context: vscode.ExtensionContext) {
   const CRAViewProvider = new CRAWebviewViewProvider(context);
 
   context.subscriptions.push(
-    vscode.commands.registerCommand("openAI.setAPIKey", setAPIKey),
+    vscode.commands.registerCommand("openAI.setAPIKey", async () => {
+      await setAPIKey(context);
+    }),
     vscode.commands.registerCommand("openAI.setModel", showModelSelectionQuickPick),
     vscode.window.registerWebviewViewProvider("craView", CRAViewProvider, {
       // Webview 등록

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -1,12 +1,11 @@
 import * as vscode from "vscode";
 import CRAWebviewViewProvider from "./webview";
-import { showModelSelectionQuickPick, setAPIKey } from "./craConfigManager";
+import { showModelSelectionQuickPick, setAPIKey, onFirstActivation } from "./craConfigManager";
 
 export async function activate(context: vscode.ExtensionContext) {
   const isInitialized = context.globalState.get<boolean>("isInitialized");
   if (!isInitialized) {
-    await setAPIKey(context);
-    await showModelSelectionQuickPick();
+    await onFirstActivation(context);
 
     context.globalState.update("isInitialized", true);
   }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -2,7 +2,15 @@ import * as vscode from "vscode";
 import CRAWebviewViewProvider from "./webview";
 import { showModelSelectionQuickPick, setAPIKey } from "./craConfigManager";
 
-export function activate(context: vscode.ExtensionContext) {
+export async function activate(context: vscode.ExtensionContext) {
+  const isInitialized = context.globalState.get<boolean>("isInitialized");
+  if (!isInitialized) {
+    await setAPIKey(context);
+    await showModelSelectionQuickPick();
+
+    context.globalState.update("isInitialized", true);
+  }
+
   const CRAViewProvider = new CRAWebviewViewProvider(context);
 
   context.subscriptions.push(

--- a/src/webview.ts
+++ b/src/webview.ts
@@ -2,7 +2,7 @@ import * as vscode from "vscode";
 import * as path from "path";
 import * as fs from "fs";
 import OpenAI from "openai";
-import { setAPIKey } from "./craConfigManager";
+import { showApiKeyError } from "./craConfigManager";
 
 export default class CRAWebviewViewProvider implements vscode.WebviewViewProvider {
   private apiKey?: string;
@@ -97,14 +97,7 @@ export default class CRAWebviewViewProvider implements vscode.WebviewViewProvide
 
   private async setOpenaiWithApiKey(apiKey: string | undefined) {
     if (!apiKey) {
-      const result = await vscode.window.showErrorMessage(
-        "OpenAI API key is not configured.\nWant to configure?",
-        "YES",
-        "NO"
-      );
-      if (result === "YES") {
-        setAPIKey(this.context);
-      }
+      showApiKeyError(this.context);
     }
 
     this.openai = new OpenAI({

--- a/src/webview.ts
+++ b/src/webview.ts
@@ -2,6 +2,7 @@ import * as vscode from "vscode";
 import * as path from "path";
 import * as fs from "fs";
 import OpenAI from "openai";
+import { setAPIKey } from "./craConfigManager";
 
 export default class CRAWebviewViewProvider implements vscode.WebviewViewProvider {
   private apiKey?: string;
@@ -94,7 +95,18 @@ export default class CRAWebviewViewProvider implements vscode.WebviewViewProvide
     }
   }
 
-  private setOpenaiWithApiKey(apiKey: string | undefined) {
+  private async setOpenaiWithApiKey(apiKey: string | undefined) {
+    if (!apiKey) {
+      const result = await vscode.window.showErrorMessage(
+        "OpenAI API key is not configured.\nWant to configure?",
+        "YES",
+        "NO"
+      );
+      if (result === "YES") {
+        setAPIKey(this.context);
+      }
+    }
+
     this.openai = new OpenAI({
       apiKey: this.apiKey,
     });


### PR DESCRIPTION
## #️⃣연관된 이슈

> #27 

## 📝작업 내용

> Extension 처음 실행 시 초기 설정이 작동함. (`onFirstActivation` 함수)
> Extension Activate시 API Key의 유효성을 검증하여 입력받음 (`checkApiKeyValidation` 함수)
> API Key 유효하지 않을 시 에러메시지 출력부 함수화 (`showApiKeyError` 함수)

## 💬리뷰 요구사항(선택)

1. 메서드 이름 적절한지 검토
2. 본인 컴퓨터에서 토큰 지우는 기능이 구현 안되어 테스트가 안되기에 #27  브랜치로 이동하여 테스트 부탁
