### PR TITLE
[fix #80] Definition messageTypes no longer display trash icons

### DIFF
--- a/webview-ui/src/components/ChatContent.tsx
+++ b/webview-ui/src/components/ChatContent.tsx
@@ -71,9 +71,11 @@ function MessageBox({
         </div>
       </div>
       <div className="message-icon">
-        <div className="message-icon-trash" onClick={() => deleteMessage(index)}>
-          <VscTrash />
-        </div>
+        {messageType !== "Definition" && (
+          <div className="message-icon-trash" onClick={() => deleteMessage(index)}>
+            <VscTrash />
+          </div>
+        )}
       </div>
     </div>
   );


### PR DESCRIPTION
## #️⃣연관된 이슈

> #80 

## 📝작업 내용

> If the messageType is "Definition", then the "message-icon-trash" icon is not displayed -> which calls deleteMessage() on click.
