### PR TITLE
114 change message state uneditable after send message to gpt

### DIFF
--- a/webview-ui/src/components/ChatInput.tsx
+++ b/webview-ui/src/components/ChatInput.tsx
@@ -9,7 +9,7 @@ import { vscode } from "../utilities/vscode";
 
 function ChatInput() {
   const inputRef = useRef<HTMLInputElement>(null);
-  const { messages, addMessage, stepCount, timestamp, setTimestamp } = useMessagesStore();
+  const { messages, addMessage, stepCount, timestamp, setTimestamp, updateMessagesEditableState } = useMessagesStore();
   const [inputType, setInputType] = useState(messages.length > 0 ? "Step" : "Definition");
   const [isComposing, setIsComposing] = useState(false);
 
@@ -47,6 +47,7 @@ function ChatInput() {
         handleSendMessage();
       } else if (isLogMessagesShortcut) {
         e.preventDefault();
+        updateMessagesEditableState(false);
         openai.sendInitMessage(combineMessages(messages, stepCount));
         window.postMessage({ command: "setLoading", data: true });
         setInputType("additional");
@@ -72,7 +73,7 @@ function ChatInput() {
       const message: Message = {
         type: inputType,
         content: input.innerText.trim(),
-        editable: inputType !== "Definition" && inputType !== "Additional",
+        editable: true,
       };
       addMessage(message);
       input.innerText = "";

--- a/webview-ui/src/stores/messagesStore.ts
+++ b/webview-ui/src/stores/messagesStore.ts
@@ -32,6 +32,13 @@ const useMessagesStore = create<MessagesState>((set) => ({
       stepCount: messages.filter((msg) => msg.type === "step").length,
     }),
   setTimestamp: (timestamp) => set({ timestamp }),
+  updateMessagesEditableState: (newState) =>
+    set((state) => ({
+      messages: state.messages.map((msg) => ({
+        ...msg,
+        editable: newState,
+      })),
+    })),
 }));
 
 export default useMessagesStore;

--- a/webview-ui/src/types/messageStoreTypes.d.ts
+++ b/webview-ui/src/types/messageStoreTypes.d.ts
@@ -15,4 +15,5 @@ export interface MessagesState {
   updateMessage: (index: number, newMessage: string) => void;
   loadMessages: (messages: Message[]) => void;
   setTimestamp: (timestamp: number) => void;
+  updateMessagesEditableState: (newState: boolean) => void;
 }


### PR DESCRIPTION
## #️⃣연관된 이슈

> ex) #114

## 📝작업 내용

> cmd+enter 눌러 gpt 에게 답 전달하면, 이전에 있었던 step, Additional(추가 질문) 등의 블록들 editable 불가. (새로 입력할 추가질문들은 수정 가능)

### 스크린샷 (선택)
<img width="546" alt="Screenshot 2025-02-07 at 2 57 36 PM" src="https://github.com/user-attachments/assets/3639f2e7-43cb-4996-ad93-d950ea20bf15" />

## 💬리뷰 요구사항(선택)

> 버그 있는지 확인 부탁합니다
> 더 나은 로직이 있는지 검토 부탁합니다
